### PR TITLE
React-Scripts fork for Django/React setup

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -73,16 +73,23 @@ const resolveModule = (resolveFn, filePath) => {
   return resolveFn(`${filePath}.js`);
 };
 
+// Our Django app name
+const appName = process.env.appName || '';
+const appSrc = process.env.appSrc || path.join(appName, 'ui');
+const appPublic = process.env.appPublic || path.join(appSrc, 'templates');
+const appIndexJs = process.env.appIndexJs || path.join(appSrc, 'index');
+const appHtml = process.env.appHtml || path.join(appPublic, `${appName}.html`);
+
 // config after eject: we're in ./config/
 module.exports = {
   dotenv: resolveApp('.env'),
   appPath: resolveApp('.'),
   appBuild: resolveApp('build'),
-  appPublic: resolveApp('public'),
-  appHtml: resolveApp('public/index.html'),
-  appIndexJs: resolveModule(resolveApp, 'src/index'),
+  appPublic: resolveApp(appPublic),
+  appHtml: resolveApp(appHtml),
+  appIndexJs: resolveModule(resolveApp, appIndexJs),
   appPackageJson: resolveApp('package.json'),
-  appSrc: resolveApp('src'),
+  appSrc: resolveApp(appSrc),
   appTsConfig: resolveApp('tsconfig.json'),
   yarnLockFile: resolveApp('yarn.lock'),
   testsSetup: resolveModule(resolveApp, 'src/setupTests'),
@@ -100,11 +107,11 @@ module.exports = {
   dotenv: resolveApp('.env'),
   appPath: resolveApp('.'),
   appBuild: resolveApp('build'),
-  appPublic: resolveApp('public'),
-  appHtml: resolveApp('public/index.html'),
-  appIndexJs: resolveModule(resolveApp, 'src/index'),
+  appPublic: resolveApp(appPublic),
+  appHtml: resolveApp(appHtml),
+  appIndexJs: resolveModule(resolveApp, appIndexJs),
   appPackageJson: resolveApp('package.json'),
-  appSrc: resolveApp('src'),
+  appSrc: resolveApp(appSrc),
   appTsConfig: resolveApp('tsconfig.json'),
   yarnLockFile: resolveApp('yarn.lock'),
   testsSetup: resolveModule(resolveApp, 'src/setupTests'),
@@ -132,11 +139,11 @@ if (
     dotenv: resolveOwn('template/.env'),
     appPath: resolveApp('.'),
     appBuild: resolveOwn('../../build'),
-    appPublic: resolveOwn('template/public'),
-    appHtml: resolveOwn('template/public/index.html'),
-    appIndexJs: resolveModule(resolveOwn, 'template/src/index'),
+    appPublic: resolveApp(`template/${appPublic}`),
+    appHtml: resolveApp(`template/${appHtml}`),
+    appIndexJs: resolveModule(resolveApp, `template/${appIndexJs}`),
     appPackageJson: resolveOwn('package.json'),
-    appSrc: resolveOwn('template/src'),
+    appSrc: resolveOwn(`template/${appSrc}`),
     appTsConfig: resolveOwn('template/tsconfig.json'),
     yarnLockFile: resolveOwn('template/yarn.lock'),
     testsSetup: resolveModule(resolveOwn, 'template/src/setupTests'),

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -44,6 +44,7 @@ const cssRegex = /\.css$/;
 const cssModuleRegex = /\.module\.css$/;
 const sassRegex = /\.(scss|sass)$/;
 const sassModuleRegex = /\.module\.(scss|sass)$/;
+const lessRegex = /\.less$/;
 
 // common function to get style loaders
 const getStyleLoaders = (cssOptions, preProcessor) => {
@@ -197,7 +198,7 @@ module.exports = {
                 settings: { react: { version: '999.999.999' } },
               },
               ignore: false,
-              useEslintrc: false,
+              useEslintrc: true,
               // @remove-on-eject-end
             },
             loader: require.resolve('eslint-loader'),
@@ -347,6 +348,10 @@ module.exports = {
               'sass-loader'
             ),
           },
+          {
+            test: lessRegex,
+            use: getStyleLoaders({ importLoaders: 2 }, 'less-loader'),
+          },
           // "file" loader makes sure those assets get served by WebpackDevServer.
           // When you `import` an asset, you get its (virtual) filename.
           // In production, they would get copied to the `build` folder.
@@ -374,6 +379,7 @@ module.exports = {
     new HtmlWebpackPlugin({
       inject: true,
       template: paths.appHtml,
+      filename: `${process.env.appName}.html`,
     }),
     // Makes some environment variables available in index.html.
     // The public URL is available as %PUBLIC_URL% in index.html, e.g.:

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -62,6 +62,7 @@ const cssRegex = /\.css$/;
 const cssModuleRegex = /\.module\.css$/;
 const sassRegex = /\.(scss|sass)$/;
 const sassModuleRegex = /\.module\.(scss|sass)$/;
+const lessRegex = /\.less$/;
 
 // common function to get style loaders
 const getStyleLoaders = (cssOptions, preProcessor) => {
@@ -273,7 +274,7 @@ module.exports = {
                 settings: { react: { version: '999.999.999' } },
               },
               ignore: false,
-              useEslintrc: false,
+              useEslintrc: true,
               // @remove-on-eject-end
             },
             loader: require.resolve('eslint-loader'),
@@ -439,6 +440,10 @@ module.exports = {
               'sass-loader'
             ),
           },
+          {
+            test: lessRegex,
+            use: getStyleLoaders({ importLoaders: 2 }, 'less-loader'),
+          },
           // "file" loader makes sure assets end up in the `build` folder.
           // When you `import` an asset, you get its filename.
           // This loader doesn't use a "test" so it will catch all modules
@@ -465,6 +470,7 @@ module.exports = {
     new HtmlWebpackPlugin({
       inject: true,
       template: paths.appHtml,
+      filename: `${process.env.appName}.html`,
       minify: {
         removeComments: true,
         collapseWhitespace: true,
@@ -473,7 +479,7 @@ module.exports = {
         removeEmptyAttributes: true,
         removeStyleLinkTypeAttributes: true,
         keepClosingSlash: true,
-        minifyJS: true,
+        minifyJS: false, // Do not minify JS b/c it contains Django template vars
         minifyCSS: true,
         minifyURLs: true,
       },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-scripts",
+  "name": "@schrodinger/react-scripts",
   "version": "2.0.5",
   "description": "Fork of Create React App with custom react-scripts.",
   "repository": "schrodinger/ldadmin-create-react-app",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,14 +1,14 @@
 {
   "name": "react-scripts",
   "version": "2.0.5",
-  "description": "Configuration and scripts for Create React App.",
-  "repository": "facebook/create-react-app",
+  "description": "Fork of Create React App with custom react-scripts.",
+  "repository": "schrodinger/ldadmin-create-react-app",
   "license": "MIT",
   "engines": {
     "node": ">=6"
   },
   "bugs": {
-    "url": "https://github.com/facebook/create-react-app/issues"
+    "url": "https://github.com/schrodinger/ldadmin-create-react-app/issues"
   },
   "files": [
     "bin",
@@ -50,6 +50,8 @@
     "jest": "23.6.0",
     "jest-pnp-resolver": "1.0.1",
     "jest-resolve": "23.6.0",
+    "less": "^3.8.1",
+    "less-loader": "^4.1.0",
     "mini-css-extract-plugin": "0.4.3",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "pnp-webpack-plugin": "1.1.0",

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -60,6 +60,13 @@ if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
   process.exit(1);
 }
 
+if (!process.env.appName) {
+  console.log(chalk.red('You must specify a Django App Name'));
+  process.exit(1);
+} else {
+  console.log(`\nBuilding "${process.env.appName}" Django/React app`);
+}
+
 // Process CLI arguments
 const argv = process.argv.slice(2);
 const writeStatsJson = argv.indexOf('--stats') !== -1;

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -56,6 +56,13 @@ if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
   process.exit(1);
 }
 
+if (!process.env.appName) {
+  console.log(chalk.red('You must specify a Django App Name'));
+  process.exit(1);
+} else {
+  console.log(`\Serving "${process.env.appName}" Django/React app`);
+}
+
 // Tools like Cloud9 rely on this.
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
 const HOST = process.env.HOST || '0.0.0.0';


### PR DESCRIPTION
Primary: @quixotically 
Jira Ticket: [SS-24525](https://jira.schrodinger.com/browse/SS-24525)

This is the react-scripts [translation of crs.config.js](https://crucible.bb.schrodinger.com/cru/LDADMIN-178#CFR-289156) (in response to Chris' [recommendation to fork](https://crucible.bb.schrodinger.com/cru/LDADMIN-178#c204198)). The two approaches are equivalent, with the only differences here being:
* modifying webpack in place instead of the hijack/extend approach from CRS
* added environment var support: ie. build a given django app: `appName='coverpage' yarn build`
* warn if no "appName" is given (we won't know what to build!)

The approach is still the same: 
* we'll build various React apps into server/build 
* let Django serve from the build directly using the generated <appName>.html

This also requires a minor companion .eslintrc in the Django root, to allow CONTEXT to be passed as it is: 

```
{
  "extends": "react-app",
  "globals": {
    "CONTEXT": true
  }
}
```